### PR TITLE
feat: mock smtp server for email sending and receiving

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -56,5 +56,13 @@ services:
       - db
       - app
 
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - 1025:1025
+      - 8025:8025
+    networks:
+      - the-everything-shop
+
 networks:
   the-everything-shop:

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
+        "nodemailer": "^7.0.10",
         "pino": "^10.1.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
@@ -3012,6 +3013,15 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
+      "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "ts-node-dev --respawn --watch src --transpile-only src/index.ts",
     "db:dev": "npx prisma migrate dev --name init && npx prisma generate",
     "db:deploy": "npx prisma migrate deploy && npx prisma generate",
     "db:seed": "node -r dotenv/config -r ts-node/register src/db/seed.ts"
@@ -26,6 +26,7 @@
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.1",
+    "nodemailer": "^7.0.10",
     "pino": "^10.1.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/backend/src/script/sendmail.ts
+++ b/backend/src/script/sendmail.ts
@@ -1,0 +1,31 @@
+// This is a helper script for quick testing mail sending
+// Also used a an example
+
+import { sendMail } from "../util/mail";
+
+async function main() {
+    await sendMail({
+        from: "sender@example.com",
+        to: "receiver@example.com",
+        subject: "Test Mail 101",
+        text: "Hey, this mail is send to you from 'the everything shop'"
+    });
+
+    await sendMail({
+        from: "another@example.com",
+        to: "receiver@example.com",
+        subject: "Test Mail html 101",
+        html: `
+        <html>
+            <h1>HEY, I AM GOING TO SEND YOU A HTML</h1>
+
+            <p>
+                <b>this is so bold</b> <br>
+                <i>this is so italic</i>
+            </p>
+        </html>
+        `
+    })
+}
+
+main().catch(console.error);

--- a/backend/src/util/mail.ts
+++ b/backend/src/util/mail.ts
@@ -1,0 +1,25 @@
+import nodemailer from "nodemailer";
+
+export interface MailOptions {
+    from: string;
+    to: string;
+    subject: string;
+    text?: string;
+    html?: string;
+}
+
+export async function sendMail(opts: MailOptions): Promise<void> {
+    const transport = nodemailer.createTransport({
+        host: process.env.SMTP_HOST || "mailhog",
+        port: Number(process.env.SMTP_PORT) || 1025,
+        secure: false,
+    });
+
+    const info = await transport.sendMail({
+        from: opts.from,
+        to: opts.to,
+        subject: opts.subject,
+        text: opts.text,
+        html: opts.html,
+    });
+}


### PR DESCRIPTION
- Example usage: see `backend/src/script/sendmail.ts`
- Email transport logic/handler is at `backend/src/util/mail.ts`
- Ports:
  - 1025: smtp server
  - 8025: smtp webui