### PR TITLE
feat: dev container setup for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "The Everything Shop Dev",
     "dockerComposeFile": [
-        "docker-compose.yml"
+        "../docker-compose.dev.yml"
     ],
     "service": "app",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "The Everything Shop Dev",
     "dockerComposeFile": [
-        "../docker-compose.yml"
+        "docker-compose.yml"
     ],
     "service": "app",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
         "ghcr.io/devcontainers/features/git:1": {},
         "ghcr.io/devcontainers/features/node:1": {}
     },
+    "postCreateCommand": "npm install --prefix backend && npm install --prefix frontend",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "The Everything Shop Dev",
+    "dockerComposeFile": [
+        "../docker-compose.yml"
+    ],
+    "service": "app",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/node:1": {}
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "Prisma.prisma"
+            ]
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,177 @@
+services:
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      # Entrypoints
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      # Redirect HTTP to HTTPS
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      # ACME / Let's Encrypt
+      - "--certificatesresolvers.myresolver.acme.httpchallenge=true"
+      - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
+      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory" # Uncomment for testing to avoid rate limits
+      - "--certificatesresolvers.myresolver.acme.email=${ACME_EMAIL:-someone@example.me}"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    networks:
+      - tes-net
+
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    env_file: ../backend/.env
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - tes-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 2s
+      retries: 20
+
+  app:
+    build: 
+      context: ../backend
+      dockerfile: Dockerfile
+    image: the-everything-shop-backend
+    restart: unless-stopped
+    env_file: ../backend/.env
+    environment:
+      - POSTGRES_HOST=db
+    # Override working directory to match the VSCode workspace mount location
+    working_dir: /workspaces/the-everything-shop/backend
+    depends_on:
+      db:
+        condition: service_healthy
+      s3:
+        condition: service_started
+    networks:
+      - tes-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend.rule=Host(`${DOMAIN_NAME:-localhost}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.backend.entrypoints=websecure"
+      - "traefik.http.routers.backend.tls.certresolver=myresolver"
+      - "traefik.http.services.backend.loadbalancer.server.port=${APP_PORT:-8000}"
+      # Swagger
+      - "traefik.http.routers.swagger.rule=Host(`swagger.${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.swagger.entrypoints=websecure"
+      - "traefik.http.routers.swagger.tls.certresolver=myresolver"
+      - "traefik.http.routers.swagger.service=backend"
+      - "traefik.http.middlewares.swagger-prefix.addprefix.prefix=/docs"
+      - "traefik.http.routers.swagger.middlewares=swagger-prefix"
+
+  frontend:
+    build: 
+      context: ../frontend
+      dockerfile: Dockerfile
+    image: the-everything-shop-frontend
+    restart: unless-stopped
+    env_file: ../frontend/.env
+    # Override working directory to match the VSCode workspace mount location
+    working_dir: /workspaces/the-everything-shop/frontend
+    networks:
+      - tes-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.frontend.entrypoints=websecure"
+      - "traefik.http.routers.frontend.tls.certresolver=myresolver"
+      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
+
+  mailhog:
+    image: mailhog/mailhog:latest
+    networks:
+      - tes-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mailhog.rule=Host(`mail.${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.mailhog.entrypoints=websecure"
+      - "traefik.http.routers.mailhog.tls.certresolver=myresolver"
+      - "traefik.http.services.mailhog.loadbalancer.server.port=8025"
+
+  s3:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=adminpass
+    networks:
+      - tes-net
+    volumes:
+      - s3_data:/data
+    labels:
+      - "traefik.enable=true"
+      # Console (9001)
+      - "traefik.http.routers.minio-console.rule=Host(`admin.storage.${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.minio-console.service=minio-console"
+      - "traefik.http.routers.minio-console.entrypoints=websecure"
+      - "traefik.http.routers.minio-console.tls.certresolver=myresolver"
+      - "traefik.http.services.minio-console.loadbalancer.server.port=9001"
+      # API (9000)
+      - "traefik.http.routers.minio-api.rule=Host(`obj.storage.${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.minio-api.service=minio-api"
+      - "traefik.http.routers.minio-api.entrypoints=websecure"
+      - "traefik.http.routers.minio-api.tls.certresolver=myresolver"
+      - "traefik.http.services.minio-api.loadbalancer.server.port=9000"
+
+  mc:
+    image: minio/mc
+    depends_on:
+      - s3
+    networks:
+      - tes-net
+    entrypoint: >
+      sh -c "
+      until (/usr/bin/mc alias set tess3 http://s3:9000 admin adminpass --insecure); do
+      echo 'Waiting for S3...';
+      sleep 2;
+      done &&
+      echo 'Creating bucket if not exists...' &&
+      /usr/bin/mc mb --ignore-existing tess3/tes &&
+      echo 'Enable anonymous download...' &&
+      /usr/bin/mc anonymous set download tess3/tes &&
+      echo 'Done.' &&
+      exit 0
+      "
+
+  prisma-studio:
+    image: the-everything-shop-backend
+    command: npx prisma studio --port 5555 --browser none
+    # Override to workspace path so it finds schema.prisma if checked out
+    working_dir: /workspaces/the-everything-shop/backend
+    env_file:
+      - ../backend/.env
+    networks:
+      - tes-net
+    depends_on:
+      - db
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prisma.rule=Host(`db.${DOMAIN_NAME:-localhost}`)"
+      - "traefik.http.routers.prisma.entrypoints=websecure"
+      - "traefik.http.routers.prisma.tls.certresolver=myresolver"
+      - "traefik.http.services.prisma.loadbalancer.server.port=5555"
+
+volumes:
+  postgres_data:
+  s3_data:
+
+networks:
+  tes-net:
+    name: tes-net

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20
 
 WORKDIR /app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,8 @@ COPY package*.json ./
 
 RUN npm install
 
-# COPY ./prisma .
+COPY . .
+
 
 EXPOSE $APP_PORT
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:22-bookworm
+
+WORKDIR /workspaces/the-everything-shop
+
+COPY . .
+
+RUN npm install --prefix backend && npm install --prefix frontend
+
+EXPOSE 8000 3000
+
+CMD ["sleep", "infinity"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,9 +53,9 @@ services:
     restart: unless-stopped
     env_file: ./backend/.env
     environment:
-      - POSTGRES_HOST=db
-    # Match the VSCode workspace mount location
-    working_dir: /workspaces/the-everything-shop/backend
+    # Override working directory to match the VSCode workspace mount location
+    working_dir: /workspaces/the-everything-shop
+    command: sleep infinity
     depends_on:
       db:
         condition: service_healthy
@@ -65,31 +65,19 @@ services:
       - tes-net
     labels:
       - "traefik.enable=true"
+      # Backend Routing
       - "traefik.http.routers.backend.rule=Host(`${DOMAIN_NAME:-localhost}`) && PathPrefix(`/api`)"
       - "traefik.http.routers.backend.entrypoints=websecure"
       - "traefik.http.routers.backend.tls.certresolver=myresolver"
       - "traefik.http.services.backend.loadbalancer.server.port=${APP_PORT:-8000}"
-      # Swagger
+      # Swagger Routing
       - "traefik.http.routers.swagger.rule=Host(`swagger.${DOMAIN_NAME:-localhost}`)"
       - "traefik.http.routers.swagger.entrypoints=websecure"
       - "traefik.http.routers.swagger.tls.certresolver=myresolver"
       - "traefik.http.routers.swagger.service=backend"
       - "traefik.http.middlewares.swagger-prefix.addprefix.prefix=/docs"
       - "traefik.http.routers.swagger.middlewares=swagger-prefix"
-
-  frontend:
-    build: 
-      context: ./frontend
-      dockerfile: Dockerfile
-    image: the-everything-shop-frontend
-    restart: unless-stopped
-    env_file: ./frontend/.env
-    # Match the VSCode workspace mount location
-    working_dir: /workspaces/the-everything-shop/frontend
-    networks:
-      - tes-net
-    labels:
-      - "traefik.enable=true"
+      # Frontend Routing (Merged into app service)
       - "traefik.http.routers.frontend.rule=Host(`${DOMAIN_NAME:-localhost}`)"
       - "traefik.http.routers.frontend.entrypoints=websecure"
       - "traefik.http.routers.frontend.tls.certresolver=myresolver"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
       - "8080:8080"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      # - "./letsencrypt:/letsencrypt"
+      - "traefik_certificates:/letsencrypt"
     networks:
       - tes-net
 
@@ -52,7 +52,7 @@ services:
     image: the-everything-shop-backend
     restart: unless-stopped
     env_file: ./backend/.env
-    environment:
+    # environment:
     # Override working directory to match the VSCode workspace mount location
     working_dir: /workspaces/the-everything-shop
     command: sleep infinity
@@ -142,8 +142,7 @@ services:
   prisma-studio:
     image: the-everything-shop-backend
     command: npx prisma studio --port 5555 --browser none
-    # Override to workspace path so it finds schema.prisma if checked out
-    working_dir: /workspaces/the-everything-shop/backend
+    working_dir: /app
     env_file:
       - ./backend/.env
     networks:
@@ -158,6 +157,7 @@ services:
       - "traefik.http.services.prisma.loadbalancer.server.port=5555"
 
 volumes:
+  traefik_certificates:
   postgres_data:
   s3_data:
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,13 +23,14 @@ services:
       - "8080:8080"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      # - "./letsencrypt:/letsencrypt"
     networks:
       - tes-net
 
   db:
     image: postgres:15-alpine
     restart: unless-stopped
-    env_file: ../backend/.env
+    env_file: ./backend/.env
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_USER: ${POSTGRES_USER}
@@ -46,14 +47,14 @@ services:
 
   app:
     build: 
-      context: ../backend
+      context: ./backend
       dockerfile: Dockerfile
     image: the-everything-shop-backend
     restart: unless-stopped
-    env_file: ../backend/.env
+    env_file: ./backend/.env
     environment:
       - POSTGRES_HOST=db
-    # Override working directory to match the VSCode workspace mount location
+    # Match the VSCode workspace mount location
     working_dir: /workspaces/the-everything-shop/backend
     depends_on:
       db:
@@ -78,12 +79,12 @@ services:
 
   frontend:
     build: 
-      context: ../frontend
+      context: ./frontend
       dockerfile: Dockerfile
     image: the-everything-shop-frontend
     restart: unless-stopped
-    env_file: ../frontend/.env
-    # Override working directory to match the VSCode workspace mount location
+    env_file: ./frontend/.env
+    # Match the VSCode workspace mount location
     working_dir: /workspaces/the-everything-shop/frontend
     networks:
       - tes-net
@@ -156,7 +157,7 @@ services:
     # Override to workspace path so it finds schema.prisma if checked out
     working_dir: /workspaces/the-everything-shop/backend
     env_file:
-      - ../backend/.env
+      - ./backend/.env
     networks:
       - tes-net
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,10 +1,11 @@
 services:
   traefik:
-    image: traefik:v2.10
+    build:
+      context: ./traefik
+      dockerfile: Dockerfile
     command:
       - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
+      - "--providers.file.filename=/etc/traefik/dynamic.yml"
       # Entrypoints
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
@@ -22,7 +23,6 @@ services:
       - "443:443"
       - "8080:8080"
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "traefik_certificates:/letsencrypt"
     networks:
       - tes-net
@@ -63,36 +63,12 @@ services:
         condition: service_started
     networks:
       - tes-net
-    labels:
-      - "traefik.enable=true"
-      # Backend Routing
-      - "traefik.http.routers.backend.rule=Host(`${DOMAIN_NAME:-localhost}`) && PathPrefix(`/api`)"
-      - "traefik.http.routers.backend.entrypoints=websecure"
-      - "traefik.http.routers.backend.tls.certresolver=myresolver"
-      - "traefik.http.services.backend.loadbalancer.server.port=${APP_PORT:-8000}"
-      # Swagger Routing
-      - "traefik.http.routers.swagger.rule=Host(`swagger.${DOMAIN_NAME:-localhost}`)"
-      - "traefik.http.routers.swagger.entrypoints=websecure"
-      - "traefik.http.routers.swagger.tls.certresolver=myresolver"
-      - "traefik.http.routers.swagger.service=backend"
-      - "traefik.http.middlewares.swagger-prefix.addprefix.prefix=/docs"
-      - "traefik.http.routers.swagger.middlewares=swagger-prefix"
-      # Frontend Routing (Merged into app service)
-      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN_NAME:-localhost}`)"
-      - "traefik.http.routers.frontend.entrypoints=websecure"
-      - "traefik.http.routers.frontend.tls.certresolver=myresolver"
-      - "traefik.http.services.frontend.loadbalancer.server.port=3000"
 
   mailhog:
     image: mailhog/mailhog:latest
     networks:
       - tes-net
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.mailhog.rule=Host(`mail.${DOMAIN_NAME:-localhost}`)"
-      - "traefik.http.routers.mailhog.entrypoints=websecure"
-      - "traefik.http.routers.mailhog.tls.certresolver=myresolver"
-      - "traefik.http.services.mailhog.loadbalancer.server.port=8025"
+
 
   s3:
     image: minio/minio
@@ -104,20 +80,7 @@ services:
       - tes-net
     volumes:
       - s3_data:/data
-    labels:
-      - "traefik.enable=true"
-      # Console (9001)
-      - "traefik.http.routers.minio-console.rule=Host(`admin.storage.${DOMAIN_NAME:-localhost}`)"
-      - "traefik.http.routers.minio-console.service=minio-console"
-      - "traefik.http.routers.minio-console.entrypoints=websecure"
-      - "traefik.http.routers.minio-console.tls.certresolver=myresolver"
-      - "traefik.http.services.minio-console.loadbalancer.server.port=9001"
-      # API (9000)
-      - "traefik.http.routers.minio-api.rule=Host(`obj.storage.${DOMAIN_NAME:-localhost}`)"
-      - "traefik.http.routers.minio-api.service=minio-api"
-      - "traefik.http.routers.minio-api.entrypoints=websecure"
-      - "traefik.http.routers.minio-api.tls.certresolver=myresolver"
-      - "traefik.http.services.minio-api.loadbalancer.server.port=9000"
+
 
   mc:
     image: minio/mc
@@ -149,12 +112,7 @@ services:
       - tes-net
     depends_on:
       - db
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.prisma.rule=Host(`db.${DOMAIN_NAME:-localhost}`)"
-      - "traefik.http.routers.prisma.entrypoints=websecure"
-      - "traefik.http.routers.prisma.tls.certresolver=myresolver"
-      - "traefik.http.services.prisma.loadbalancer.server.port=5555"
+
 
 volumes:
   traefik_certificates:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,15 +47,21 @@ services:
 
   app:
     build: 
-      context: ./backend
-      dockerfile: Dockerfile
-    image: the-everything-shop-backend
+      context: .
+      dockerfile: dev.Dockerfile
+    image: the-everything-shop-monolith
     restart: unless-stopped
     env_file: ./backend/.env
-    # environment:
-    # Override working directory to match the VSCode workspace mount location
-    working_dir: /workspaces/the-everything-shop
-    command: sleep infinity
+    # Auto-start both services in parallel.
+    command: >
+      sh -c "
+      cd /workspaces/the-everything-shop &&
+      npm run db:dev --prefix backend &&\
+      npm run db:seed --prefix backend &&\
+      npm run dev --prefix backend &
+      npm run dev --prefix frontend -- --host 0.0.0.0 &
+      wait
+      "
     depends_on:
       db:
         condition: service_healthy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20
 
 WORKDIR /app
 

--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,0 +1,3 @@
+FROM traefik:v2.10
+
+COPY dynamic.yml /etc/traefik/dynamic.yml

--- a/traefik/dynamic.yml
+++ b/traefik/dynamic.yml
@@ -1,0 +1,95 @@
+http:
+  routers:
+    backend:
+      rule: "Host(`localhost`) && PathPrefix(`/api`)"
+      service: backend
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: myresolver
+
+    frontend:
+      rule: "Host(`localhost`)"
+      service: frontend
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: myresolver
+
+    swagger:
+      rule: "Host(`swagger.localhost`)"
+      service: backend
+      entryPoints:
+        - websecure
+      middlewares:
+        - swagger-prefix
+      tls:
+        certResolver: myresolver
+
+    minio-console:
+      rule: "Host(`admin.storage.localhost`)"
+      service: minio-console
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: myresolver
+
+    minio-api:
+      rule: "Host(`obj.storage.localhost`)"
+      service: minio-api
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: myresolver
+
+    mailhog:
+      rule: "Host(`mail.localhost`)"
+      service: mailhog
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: myresolver
+
+    prisma:
+      rule: "Host(`db.localhost`)"
+      service: prisma
+      entryPoints:
+        - websecure
+      tls:
+        certResolver: myresolver
+
+  middlewares:
+    swagger-prefix:
+      addPrefix:
+        prefix: "/docs"
+
+  services:
+    backend:
+      loadBalancer:
+        servers:
+          - url: "http://app:8000"
+    
+    frontend:
+      loadBalancer:
+        servers:
+          - url: "http://app:3000"
+
+    minio-console:
+      loadBalancer:
+        servers:
+          - url: "http://s3:9001"
+
+    minio-api:
+      loadBalancer:
+        servers:
+          - url: "http://s3:9000"
+
+    mailhog:
+      loadBalancer:
+        servers:
+          - url: "http://mailhog:8025"
+
+    prisma:
+      loadBalancer:
+        servers:
+          - url: "http://prisma-studio:5555"


### PR DESCRIPTION
# Đã setup `dev container`

Có hot reload
Đã test trên windoze

## Cách chạy dev container trên vscode:
### Mở folder gốc của project trong IDE/editor
### Bấm vô cái nút remote ở góc dưới
<img width="1397" height="725" alt="image" src="https://github.com/user-attachments/assets/b6ecae25-713c-4d59-81c5-9d763f5beacb" />


### Chọn reopen in container
Note: 
- Nếu dùng lần đầu có thể chỉ có mục `dev container`, chọn vào nó để cài extension dev container
- Nếu mạng nhà yếu thì thằng vscode nó setup dev container lâu cực
<img width="1398" height="726" alt="image" src="https://github.com/user-attachments/assets/f0859a56-a254-477d-b60a-be9e072a2032" />

### Bắt đầu dev được rồi, và App đồng thời đã tự chạy, không cần chạy docker compose up thủ công nữa

### Nhắc lại các url quan trọng (localhost):
- localhost: frontend
- db.localhost: prisma studio
- mail.localhost: mailhog (email)
- swagger.localhost: swagger
- Các api endpoint của backend sẽ không expose url ra browser. Nếu muốn test nhanh thì localhost:8000 vẫn hoạt động.

## Đã sửa một số lỗi
- Sửa lỗi database không khởi tạo được

## IDE khác
- Theo tôi nhớ thì nhà JetBrains có hỗ trợ dev container.
